### PR TITLE
Preserve relative paths in stylesheets by default

### DIFF
--- a/preprocessors.js
+++ b/preprocessors.js
@@ -109,6 +109,9 @@ module.exports.preprocessMinifyCss = function(tree, options) {
 
   if (plugins.length === 0) {
     var CleanCSS = require('broccoli-clean-css');
+    if(options.rebase === undefined) {
+      options.rebase = false;
+    }
     return new CleanCSS(tree, options);
   } else if (plugins.length > 1) {
     throw new Error('You cannot use more than one minify-css plugin at once.');


### PR DESCRIPTION
Fix for relative paths in css, reported here: https://github.com/ember-cli/ember-cli-preprocess-registry/issues/51

Introduced by clean-css (4.x.x) that ships with the new broccoli-clean-css (2.x.x) (https://github.com/ember-cli/ember-cli-preprocess-registry/commit/a7d2eeba3edf06d3639bf54833a3398c6b91cd84)

broccoli-clean-css does not seem interested in changing the default behavior themselves (https://github.com/shinnn/broccoli-clean-css/issues/18)