### PR TITLE
preprocessMinifyCss: Add `processPlugins()` as fallback for failing `relativeRequire()`

### DIFF
--- a/preprocessors.js
+++ b/preprocessors.js
@@ -116,7 +116,15 @@ module.exports.preprocessMinifyCss = function(tree, options) {
 
   var plugin = plugins[0];
 
-  return relativeRequire(plugin.name).call(null, tree, options);
+  try {
+    return relativeRequire(plugin.name).call(null, tree, options);
+  } catch (error) {
+    if (error && error.code === 'MODULE_NOT_FOUND') {
+      return processPlugins(plugins, arguments);
+    }
+
+    throw error;
+  }
 };
 
 module.exports.preprocessCss = function(tree, inputPath, outputPath, options) {


### PR DESCRIPTION
This brings the implementation closer to the `master` branch and fixes issues with the current `ember-cli-clean-css` implementation (see https://github.com/ember-cli/ember-cli-clean-css/issues/2)