### PR TITLE
Restore removing of plugins by name. This is extensively used by embroider and the addon ecosystem.

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,13 +46,23 @@ class Registry {
     registered.push(plugin);
   }
 
-  remove(type, plugin) {
+  remove(type, pluginOrName) {
     let registered = this.registeredForType(type);
-    let name = plugin.name;
+    let name, registeredIndex;
+
+    if (typeof pluginOrName === 'object') {
+      name = pluginOrName.name;
+      registeredIndex = registered.indexOf(pluginOrName);
+    } else {
+      name = pluginOrName;
+      for (let i = 0, l = registered.length; i < l; i++) {
+        if (registered[i].name === name) {
+          registeredIndex = i;
+        }
+      }
+    }
 
     debug('remove type: %s, name: %s', type, name);
-
-    let registeredIndex = registered.indexOf(plugin);
 
     if (registeredIndex > -1) {
       registered.splice(registeredIndex, 1);

--- a/tests/unit/registry-test.js
+++ b/tests/unit/registry-test.js
@@ -82,7 +82,7 @@ describe('Plugin Loader', function() {
     });
 
     it('will removed non defined extensions from list', function() {
-      registry.add('css', 'broccoli-foo');
+      registry.add('css', { name: 'broccoli-foo' });
       let extensions = registry.extensionsForType('css');
 
       expect(extensions).to.deep.equal(['css', 'scss', 'sass']);
@@ -109,6 +109,14 @@ describe('Plugin Loader', function() {
     let plugins = registry.load('css');
     expect(plugins.length).to.equal(1);
     expect(plugins[0]).to.equal(fakeSass2);
+  });
+
+  it('allows removal of a specified plugin by name', function() {
+    registry.remove('css', 'fake-sass-2');
+
+    let plugins = registry.load('css');
+    expect(plugins.length).to.equal(1);
+    expect(plugins[0]).to.equal(fakeSass1);
   });
 
   it('allows removal of plugin added as instantiated objects', function() {
@@ -144,7 +152,7 @@ describe('Plugin Loader', function() {
 
     expect(plugins).to.deep.eql([blah, blammo]);
 
-    registry.remove('foo', blah);
+    registry.remove('foo', 'blah-zorz');
     plugins = registry.load('foo');
 
     expect(plugins).to.eql([blammo]);


### PR DESCRIPTION
Found via extensive debugging from @ef4 and the two failing tests on this PR https://github.com/ember-cli/ember-cli/pull/10244